### PR TITLE
Allow scoped sockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-socket-hooks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A set of react hooks to work real nice with the WebSocket API",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^16.8.4",
     "react-hooks-testing-library": "^0.4.0",
     "react-test-renderer": "^16.8.4",
+    "react-testing-library": "^6.1.2",
     "rimraf": "^2.6.3"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export useSocket from "./socket";
+export { Provider as SocketScope } from "./scope";

--- a/src/message-handler.js
+++ b/src/message-handler.js
@@ -1,4 +1,5 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
+import useSocketSubscription from "./subscribe";
 
 const useMessageHandler = ({ socket, onMessage }) => {
 	const messageHandler = useCallback(
@@ -10,17 +11,7 @@ const useMessageHandler = ({ socket, onMessage }) => {
 		[onMessage]
 	);
 
-	useEffect(() => {
-		if (socket) {
-			socket.addEventListener("message", messageHandler);
-		}
-
-		return () => {
-			if (socket) {
-				socket.removeEventListener("message", messageHandler);
-			}
-		};
-	}, [messageHandler, socket]);
+	useSocketSubscription(socket, "message", messageHandler);
 };
 
 export default useMessageHandler;

--- a/src/open-handler.js
+++ b/src/open-handler.js
@@ -1,4 +1,5 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
+import useSocketSubscription from "./subscribe";
 
 const useOpenHandler = ({ messageQueue, send, socket }) => {
 	const openHandler = useCallback(() => {
@@ -9,13 +10,7 @@ const useOpenHandler = ({ messageQueue, send, socket }) => {
 		}
 	}, [messageQueue, send]);
 
-	useEffect(() => {
-		if (socket) {
-			socket.addEventListener("open", openHandler);
-		}
-
-		return () => socket && socket.close();
-	}, [openHandler, socket]);
+	useSocketSubscription(socket, "open", openHandler);
 };
 
 export default useOpenHandler;

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,61 @@
+import React, {
+	createContext,
+	useState,
+	useMemo,
+	useCallback,
+	useContext
+} from "react";
+
+const SocketScopeContext = createContext();
+
+export const useSocketScope = () => useContext(SocketScopeContext);
+
+export const Provider = ({ children }) => {
+	const [, setSockets] = useState({});
+
+	const acquire = useCallback(url => {
+		let s;
+
+		setSockets(sockets => {
+			if (sockets[url]) {
+				s = sockets[url].socket;
+				return {
+					...sockets,
+					[url]: { ...sockets[url], count: sockets[url].count + 1 }
+				};
+			}
+
+			s = new WebSocket(url);
+			return { ...sockets, [url]: { socket: s, count: 1 } };
+		});
+
+		return s;
+	}, []);
+
+	const release = useCallback(url => {
+		setSockets(sockets => {
+			const s = sockets[url];
+			if (!s) return sockets;
+
+			const newCount = s.count - 1;
+
+			if (newCount == 0) {
+				s.socket.close();
+				return { ...sockets, [url]: null };
+			}
+
+			return {
+				...sockets,
+				[url]: { ...s, count: newCount }
+			};
+		});
+	}, []);
+
+	const ctxVal = useMemo(() => ({ acquire, release }), [acquire, release]);
+
+	return (
+		<SocketScopeContext.Provider value={ctxVal}>
+			{children}
+		</SocketScopeContext.Provider>
+	);
+};

--- a/src/socket-instance.js
+++ b/src/socket-instance.js
@@ -1,17 +1,29 @@
 import { useEffect, useState } from "react";
+import { useSocketScope } from "./scope";
 
 const useSocketInstance = url => {
 	const [socket, setSocket] = useState(null);
+	const scope = useSocketScope();
 
 	useEffect(() => {
 		let s;
 		if (url) {
-			s = new WebSocket(url);
-			setSocket(s);
+			if (scope) {
+				s = scope.acquire(url);
+			} else {
+				s = new WebSocket(url);
+				setSocket(s);
+			}
 		}
 
-		return () => s && s.close();
-	}, [url]);
+		return () => {
+			if (scope && url) {
+				scope.release(url);
+			} else if (s) {
+				s.close();
+			}
+		};
+	}, [scope, url]);
 
 	return socket;
 };

--- a/src/socket-instance.js
+++ b/src/socket-instance.js
@@ -3,27 +3,31 @@ import { useSocketScope } from "./scope";
 
 const useSocketInstance = url => {
 	const [socket, setSocket] = useState(null);
-	const scope = useSocketScope();
+	const acquireScopedSocket = useSocketScope();
 
 	useEffect(() => {
 		let s;
+
 		if (url) {
-			if (scope) {
-				s = scope.acquire(url);
+			if (acquireScopedSocket) {
+				s = acquireScopedSocket(url);
 			} else {
 				s = new WebSocket(url);
-				setSocket(s);
 			}
+
+			setSocket(s);
 		}
 
 		return () => {
-			if (scope && url) {
-				scope.release(url);
-			} else if (s) {
-				s.close();
+			if (s) {
+				if (s.release) {
+					s.release(url);
+				} else {
+					s.close();
+				}
 			}
 		};
-	}, [scope, url]);
+	}, [acquireScopedSocket, url]);
 
 	return socket;
 };

--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+const useSocketSubscription = (socket, event, handler) =>
+	useEffect(() => {
+		if (socket) {
+			socket.addEventListener(event, handler);
+		}
+
+		return () => {
+			if (socket) {
+				socket.removeEventListener(event, handler);
+			}
+		};
+	}, [event, handler, socket]);
+
+export default useSocketSubscription;

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,2 +1,4 @@
 extends:
   - civicsource/mocha
+rules:
+  react/jsx-no-bind: off

--- a/test/mock-websocket.js
+++ b/test/mock-websocket.js
@@ -1,4 +1,5 @@
 import Emitter from "eventemitter3";
+import { expect } from "chai";
 
 export default function() {
 	beforeEach(function() {
@@ -49,6 +50,13 @@ export default function() {
 			triggerMessage(message) {
 				this.emit("message", { data: JSON.stringify(message) });
 			}
+		};
+	});
+
+	beforeEach(function() {
+		this.ensureSingleSocket = () => {
+			expect(this.sockets).to.have.lengthOf(1);
+			return this.sockets[0];
 		};
 	});
 

--- a/test/using-scoped-socket.js
+++ b/test/using-scoped-socket.js
@@ -137,4 +137,55 @@ describe("Using scoped sockets", function() {
 			});
 		});
 	});
+
+	describe("when rendering multiple socket hooks from within multiple scopes", function() {
+		beforeEach(function() {
+			const App = () => (
+				<>
+					<SocketScope>
+						<MySocket url={FAKE_URL1} />
+						<MySocket url={FAKE_URL1} />
+						<MySocket url={FAKE_URL1} />
+					</SocketScope>
+					<SocketScope>
+						<MySocket url={FAKE_URL1} />
+						<MySocket url={FAKE_URL2} />
+						<MySocket url={FAKE_URL2} />
+					</SocketScope>
+				</>
+			);
+
+			render(<App />);
+		});
+
+		it("should open multiple socket connections", function() {
+			expect(this.sockets).to.have.lengthOf(3);
+
+			expect(this.sockets[0].url).to.equal(FAKE_URL1);
+			expect(this.sockets[1].url).to.equal(FAKE_URL1);
+			expect(this.sockets[2].url).to.equal(FAKE_URL2);
+		});
+	});
+
+	describe("when rendering multiple socket hooks with no scopes", function() {
+		beforeEach(function() {
+			const App = () => (
+				<>
+					<MySocket url={FAKE_URL1} />
+					<MySocket url={FAKE_URL1} />
+					<MySocket url={FAKE_URL1} />
+				</>
+			);
+
+			render(<App />);
+		});
+
+		it("should open multiple socket connections", function() {
+			expect(this.sockets).to.have.lengthOf(3);
+
+			expect(this.sockets[0].url).to.equal(FAKE_URL1);
+			expect(this.sockets[1].url).to.equal(FAKE_URL1);
+			expect(this.sockets[2].url).to.equal(FAKE_URL1);
+		});
+	});
 });

--- a/test/using-scoped-socket.js
+++ b/test/using-scoped-socket.js
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+import behavesLikeBrowser from "./behaves-like-browser";
+import mockWebSocket from "./mock-websocket";
+import { render, cleanup, act } from "react-testing-library";
+
+import React, { useState } from "react";
+
+import { useSocket, SocketScope } from "../src";
+
+const MySocket = ({ url }) => {
+	useSocket(url);
+	return <span>ohhai</span>;
+};
+
+const FAKE_URL1 = "wss://api.example.com/1";
+const FAKE_URL2 = "wss://api.example.com/2";
+
+describe("useSocket with SocketScope", function() {
+	afterEach(cleanup);
+	behavesLikeBrowser();
+	mockWebSocket();
+
+	describe("when rendering multiple socket hooks within one scope", function() {
+		beforeEach(function() {
+			const App = () => {
+				const [url1, setUrl1] = useState("");
+				const [url2, setUrl2] = useState("");
+				const [url3, setUrl3] = useState("");
+
+				this.setUrl1 = setUrl1;
+				this.setUrl2 = setUrl2;
+				this.setUrl3 = setUrl3;
+
+				return (
+					<SocketScope>
+						<MySocket url={url1} />
+						<MySocket url={url2} />
+						<MySocket url={url3} />
+					</SocketScope>
+				);
+			};
+
+			render(<App />);
+		});
+
+		it("should not open any socket connections", function() {
+			expect(this.sockets).to.be.empty;
+		});
+
+		describe("with the same URL", function() {
+			beforeEach(function() {
+				act(() => {
+					this.setUrl1(FAKE_URL1);
+					this.setUrl2(FAKE_URL1);
+					this.setUrl3(FAKE_URL1);
+				});
+			});
+
+			it("should only open one socket connection", function() {
+				const s = this.ensureSingleSocket();
+				expect(s.url).to.equal(FAKE_URL1);
+			});
+
+			describe("and then disabling all but one socket hook", function() {
+				beforeEach(function() {
+					act(() => {
+						this.setUrl2("");
+						this.setUrl3("");
+					});
+				});
+
+				it("should not close socket", function() {
+					const socket = this.ensureSingleSocket();
+					expect(socket.readyState).to.equal(global.WebSocket.CONNECTING);
+				});
+			});
+
+			describe("and then disabling all socket hooks", function() {
+				beforeEach(function() {
+					act(() => {
+						this.setUrl1("");
+						this.setUrl2("");
+						this.setUrl3("");
+					});
+				});
+
+				it("should close the socket", function() {
+					const socket = this.ensureSingleSocket();
+					expect(socket.readyState).to.equal(global.WebSocket.CLOSED);
+				});
+			});
+		});
+
+		describe("with different URLs", function() {
+			beforeEach(function() {
+				act(() => {
+					this.setUrl1(FAKE_URL1);
+					this.setUrl2(FAKE_URL2);
+					this.setUrl3(FAKE_URL2);
+				});
+			});
+
+			it("should open multiple socket connections despite socket scope", function() {
+				expect(this.sockets).to.have.lengthOf(2);
+
+				expect(this.sockets[0].url).to.equal(FAKE_URL1);
+				expect(this.sockets[1].url).to.equal(FAKE_URL2);
+			});
+		});
+	});
+});

--- a/test/using-socket.js
+++ b/test/using-socket.js
@@ -5,17 +5,10 @@ import { renderHook, cleanup, act } from "react-hooks-testing-library";
 
 import { useSocket } from "../src";
 
-describe("When rendering a component with useSocket", function() {
+describe("Using sockets", function() {
 	afterEach(cleanup);
 	behavesLikeBrowser();
 	mockWebSocket();
-
-	beforeEach(function() {
-		this.ensureSingleSocket = () => {
-			expect(this.sockets).to.have.lengthOf(1);
-			return this.sockets[0];
-		};
-	});
 
 	it("should expose a send callback which sends on the socket", function() {
 		const { result } = renderHook(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,6 +3542,14 @@ react-testing-library@^6.0.3:
     "@babel/runtime" "^7.4.2"
     dom-testing-library "^3.19.0"
 
+react-testing-library@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-6.1.2.tgz#f6bba6eeecedac736eb00b22b4c70bae04535a4f"
+  integrity sha512-z69lhRDGe7u/NOjDCeFRoe1cB5ckJ4656n0tj/Fdcr6OoBUu7q9DBw0ftR7v5i3GRpdSWelnvl+feZFOyXyxwg==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    dom-testing-library "^3.19.0"
+
 react@^16.8.4:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.4.tgz#fdf7bd9ae53f03a9c4cd1a371432c206be1c4768"


### PR DESCRIPTION
This adds an export, `ScopedSocket` that when used forces any socket hooks used underneath it for the same URL to use the same socket connection.

It uses context under the covers to make this work.

### Usage

App entry point:

```jsx
<ScopedSocket>
  {/* my other components */}
</ScopedSocket>
```

later inside a component:

```js
const MyComponent = props => {
  useSocket("wss://api.example.com/");

  return <span>ohhai</span>;
}
```

`MyComponent` can be used multiple times from within `ScopedSocket` and only one socket connection will ever be opened.