### PR TITLE
Don't blow up on server-side render

### DIFF
--- a/src/.eslintrc.yml
+++ b/src/.eslintrc.yml
@@ -1,2 +1,4 @@
 env:
   browser: true
+globals:
+  global: readonly

--- a/src/registry.js
+++ b/src/registry.js
@@ -10,7 +10,7 @@ const useSocketRegistry = (delay = 100) => {
 				let socket = sockets.current[url];
 
 				if (
-					!socket ||
+					(global.WebSocket && !socket) ||
 					(socket &&
 						keepAlive &&
 						socket.readyState != WebSocket.CONNECTING &&

--- a/src/send-handler.js
+++ b/src/send-handler.js
@@ -3,6 +3,11 @@ import { useCallback } from "react";
 const useSendHandler = ({ socket, messageQueue }) =>
 	useCallback(
 		message => {
+			if (!global.WebSocket) {
+				throw new Error(
+					"Attempt to send WebSocket message in unsupported environment."
+				);
+			}
 			if (socket && socket.readyState === WebSocket.OPEN) {
 				socket.send(JSON.stringify(message));
 			} else {

--- a/test/mock-timers.js
+++ b/test/mock-timers.js
@@ -1,0 +1,11 @@
+import { useFakeTimers } from "sinon";
+
+export default function() {
+	beforeEach(function() {
+		this.clock = useFakeTimers();
+	});
+
+	afterEach(function() {
+		this.clock.restore();
+	});
+}

--- a/test/mock-websocket.js
+++ b/test/mock-websocket.js
@@ -1,17 +1,7 @@
 import Emitter from "eventemitter3";
 import { expect } from "chai";
 
-import { useFakeTimers } from "sinon";
-
 export default function() {
-	beforeEach(function() {
-		this.clock = useFakeTimers();
-	});
-
-	afterEach(function() {
-		this.clock.restore();
-	});
-
 	beforeEach(function() {
 		let sockets = (this.sockets = []);
 

--- a/test/using-scoped-socket.js
+++ b/test/using-scoped-socket.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import behavesLikeBrowser from "./behaves-like-browser";
 import mockWebSocket from "./mock-websocket";
+import mockTimers from "./mock-timers";
 import { render, cleanup, act } from "react-testing-library";
 
 import React, { useState } from "react";
@@ -19,6 +20,7 @@ describe("Using scoped sockets", function() {
 	afterEach(cleanup);
 	behavesLikeBrowser();
 	mockWebSocket();
+	mockTimers();
 
 	describe("when rendering multiple socket hooks within one scope", function() {
 		beforeEach(function() {

--- a/test/using-socket-hook-in-ssr.js
+++ b/test/using-socket-hook-in-ssr.js
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { renderHook, cleanup } from "react-hooks-testing-library";
+import behavesLikeBrowser from "./behaves-like-browser";
+import mockTimers from "./mock-timers";
+import { useSocket } from "../src";
+
+describe("Using socket hook in server-side rendering", function() {
+	afterEach(cleanup);
+	behavesLikeBrowser();
+	mockTimers();
+
+	describe("when rendering a socket hook in a non-browser environment", function() {
+		let result;
+
+		beforeEach(function() {
+			const r = renderHook(({ url }) => useSocket(url), {
+				initialProps: { url: "wss://api.example.com/" }
+			});
+			result = r.result;
+			this.clock.tick(1000);
+		});
+
+		it("should expose a send callback", function() {
+			expect(result.current.send).to.be.a("function");
+		});
+
+		describe("when calling send callback on server", function() {
+			it("should throw", function() {
+				expect(result.current.send).to.throw();
+			});
+		});
+
+		it("should return undefined ready state", function() {
+			expect(result.current.readyState).to.be.undefined;
+		});
+	});
+});

--- a/test/using-socket-keep-alive.js
+++ b/test/using-socket-keep-alive.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { expect } from "chai";
 import behavesLikeBrowser from "./behaves-like-browser";
 import mockWebSocket from "./mock-websocket";
+import mockTimers from "./mock-timers";
 import { renderHook, cleanup, act } from "react-hooks-testing-library";
 import { render } from "react-testing-library";
 
@@ -18,6 +19,7 @@ describe("Using sockets with keep-alive option", function() {
 	afterEach(cleanup);
 	behavesLikeBrowser();
 	mockWebSocket();
+	mockTimers();
 
 	describe("when rendering a socket hook with keep-alive option", function() {
 		let result;

--- a/test/using-socket.js
+++ b/test/using-socket.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import behavesLikeBrowser from "./behaves-like-browser";
 import mockWebSocket from "./mock-websocket";
+import mockTimers from "./mock-timers";
 import { renderHook, cleanup, act } from "react-hooks-testing-library";
 
 import { useSocket } from "../src";
@@ -9,6 +10,7 @@ describe("Using sockets", function() {
 	afterEach(cleanup);
 	behavesLikeBrowser();
 	mockWebSocket();
+	mockTimers();
 
 	describe("when rendering a socket hook", function() {
 		let result, rerender;


### PR DESCRIPTION
- Check for `WebSocket` before calling its constructor
- Throw an exception when send is called in an unsupported environment

Maybe one day: Allow populating the send queue instead of throwing?