### PR TITLE
Rework API around receiving socket messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 > A set of react hooks to work real nice with the WebSocket API.
 
 ```js
-const mySocketMessageHandler = msg => console.log(msg);
+import { useCallback } from "react";
+import useSocket from "react-socket-hooks";
 
-const { send } = useSocket("wss://example.com", { onMessage: mySocketMessageHandler });
+const mySocketMessageHandler1 = useCallback(msg => console.log(msg), []);
+const mySocketMessageHandler2 = useCallback(msg => console.log("ohmy", msg), []);
+
+const { useMessageHandler, send } = useSocket("wss://example.com");
+useMessageHandler(mySocketMessageHandler1);
+useMessageHandler(mySocketMessageHandler2);
 
 // …later, perhaps in response to a user action
 send("hello, server");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-socket-hooks",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A set of react hooks to work real nice with the WebSocket API",
   "keywords": [
     "react",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const useMessageQueue = () => useRef([]);
 
 const useSocket = (
 	url,
-	{ onMessage, keepAlive, keepAliveMaxDelay = 15000, socketDelay } = {}
+	{ keepAlive, keepAliveMaxDelay = 15000, socketDelay } = {}
 ) => {
 	const [keepAliveAttempts, setKeepAliveAttempts] = useState(0);
 
@@ -35,9 +35,9 @@ const useSocket = (
 
 	const send = useSendHandler({ socket, messageQueue });
 	useOpenHandler({ messageQueue, send, socket });
-	useMessageHandler({ socket, onMessage });
 
 	return {
+		useMessageHandler: onMessage => useMessageHandler(socket, onMessage),
 		readyState,
 		keepAliveAttempts,
 		send

--- a/src/message-handler.js
+++ b/src/message-handler.js
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import useSocketSubscription from "./subscribe";
 
-const useMessageHandler = ({ socket, onMessage }) => {
+const useMessageHandler = (socket, onMessage) => {
 	const messageHandler = useCallback(
 		evt => {
 			if (evt && evt.data && onMessage) {

--- a/src/send-handler.js
+++ b/src/send-handler.js
@@ -8,6 +8,7 @@ const useSendHandler = ({ socket, messageQueue }) =>
 					"Attempt to send WebSocket message in unsupported environment."
 				);
 			}
+
 			if (socket && socket.readyState === WebSocket.OPEN) {
 				socket.send(JSON.stringify(message));
 			} else {

--- a/test/using-socket-keep-alive.js
+++ b/test/using-socket-keep-alive.js
@@ -20,14 +20,20 @@ describe("Using sockets with keep-alive option", function() {
 		beforeEach(function() {
 			socketSink = null;
 
-			const r = renderHook(() =>
-				useSocket("wss://api.example.com/", {
-					keepAlive: true,
-					onMessage: message => {
-						socketSink = message;
+			const r = renderHook(() => {
+				const { useMessageHandler, ...result } = useSocket(
+					"wss://api.example.com/",
+					{
+						keepAlive: true
 					}
-				})
-			);
+				);
+
+				useMessageHandler(message => {
+					socketSink = message;
+				});
+
+				return result;
+			});
 			result = r.result;
 
 			this.clock.tick(1000);

--- a/test/using-socket.js
+++ b/test/using-socket.js
@@ -228,13 +228,17 @@ describe("Using sockets", function() {
 		let socketSink;
 
 		beforeEach(function() {
-			renderHook(() =>
-				useSocket("wss://api.example.com/", {
-					onMessage: message => {
-						socketSink = message;
-					}
-				})
-			);
+			renderHook(() => {
+				const { useMessageHandler, ...result } = useSocket(
+					"wss://api.example.com/"
+				);
+
+				useMessageHandler(message => {
+					socketSink = message;
+				});
+
+				return result;
+			});
 		});
 
 		describe("and then receiving a message", function() {


### PR DESCRIPTION
Instead of an `onMessage`, return a pre-wired hook from the hook.

```js
import { useCallback } from "react";
import useSocket from "react-socket-hooks";

const mySocketMessageHandler = useCallback(msg => console.log(msg), []);

const { useMessageHandler } = useSocket("wss://example.com");
useMessageHandler(mySocketMessageHandler);
```

![yo dawg I heard you like hooks](https://i.imgflip.com/34pq3m.jpg)